### PR TITLE
MANIFEST.in should include itself so source distributions could be bu…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include *.py *.txt *.rst
+include *.py *.txt *.rst MANIFEST.in
 recursive-include docs *.rst *.py make.bat Makefile
 


### PR DESCRIPTION
…ilt from source distributions

We're using stdb (https://pypi.python.org/pypi/stdeb/0.8.5) to build debian packages from the source distribution of contextlib2, and it fails becasue MANIFEST.in is not in the tgz
This